### PR TITLE
chore: update deps & fix broken build status badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 📌 Maintain One Comment
 
-![](https://img.shields.io/github/workflow/status/actions-cool/maintain-one-comment/CI?style=flat-square)
+[![](https://github.com/actions-cool/maintain-one-comment/actions/workflows/test.yml/badge.svg)](https://github.com/actions-cool/maintain-one-comment/actions/workflows/test.yml)
 [![](https://img.shields.io/badge/marketplace-maintain--one--comment-blueviolet?style=flat-square)](https://github.com/marketplace/actions/maintain-one-comment)
 [![](https://img.shields.io/github/v/release/actions-cool/maintain-one-comment?style=flat-square&color=orange)](https://github.com/actions-cool/maintain-one-comment/releases)
 

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "pub": "sh -e ./scripts/pub.sh"
   },
   "dependencies": {
-    "@actions/core": "^1.2.6",
-    "@actions/github": "^4.0.0",
-    "@octokit/rest": "^18.0.14",
-    "actions-util": "^1.0.0"
+    "@actions/core": "^1.10.0",
+    "@actions/github": "^5.1.1",
+    "@octokit/rest": "^19.0.13",
+    "actions-util": "^1.1.4"
   },
   "devDependencies": {
     "@umijs/fabric": "^2.5.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@umijs/fabric": "^2.5.6",
-    "@vercel/ncc": "^0.27.0",
+    "@vercel/ncc": "^0.36.1",
     "chalk": "^4.1.2",
     "new-github-release-url": "^1.0.0",
     "open": "^7.3.0",


### PR DESCRIPTION
Hi @xrkffgg, thanks for the awesome action library! I'm opening this PR to try to fix two issues:

1. Fix the deprecation warning about the `set-output` command by upgrading the dependencies

> :warning: Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

2. Fix the broken build status badge in README.md

| Before | After |
| :------: | :------: |
| ![Before](https://github.com/actions-cool/maintain-one-comment/assets/26999792/09b948f3-559d-4649-8a0f-05d7b8722c68) | ![After](https://github.com/actions-cool/maintain-one-comment/assets/26999792/90957a75-19d3-4735-af4d-a801158181fc) |