### PR TITLE
Bump to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,5 +33,5 @@ outputs:
     description: 'Create or update comment ID'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/