### PR TITLE
upgrade node version to v20 & update dependencies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,5 +33,5 @@ outputs:
     description: 'Create or update comment ID'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "pub": "sh -e ./scripts/pub.sh"
   },
   "dependencies": {
-    "@actions/core": "^1.10.0",
-    "@actions/github": "^5.1.1",
-    "@octokit/rest": "^19.0.13",
+    "@actions/core": "^1.10.1",
+    "@actions/github": "^6.0.0",
+    "@octokit/rest": "^20.0.2",
     "actions-util": "^1.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
To fix the deprecation warning and update the dependencies

> [!WARNING] 
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: ./.actions/maintain-one-comment. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

/ping @xrkffgg 